### PR TITLE
Adding .json suffix to metadata call; Firefox on Mac needs this

### DIFF
--- a/src/cljx/milia/api/dataset.cljx
+++ b/src/cljx/milia/api/dataset.cljx
@@ -129,7 +129,7 @@
 (defn metadata
   "Show dataset metadata."
   [account dataset-id]
-  (let [url (make-url "forms" dataset-id)]
+  (let [url (make-url "forms" (str dataset-id ".json"))]
     (parse-http :get url account)))
 
 #+clj

--- a/tests/clj/milia/api/dataset_test.clj
+++ b/tests/clj/milia/api/dataset_test.clj
@@ -39,7 +39,7 @@
          (fact "should get dataset metadata"
                (metadata account :dataset-id) => :fake-metadata
                (provided
-                (make-url "forms" :dataset-id) => url
+                (make-url "forms" ":dataset-id.json") => url
                 (parse-http :get url account) => :fake-metadata)))
 
   (fact "about dataset-getdata"


### PR DESCRIPTION
So Zebra and Hatti dataviews aren't working properly on MacOSX. This change is needed to fix them. Should I also include a version bump with this PR? If so, what to bump it to from 0.1.2?