### PR TITLE
AR Added a fix for error 400 thrown when changing a password

### DIFF
--- a/src/clj/milia/api/user.clj
+++ b/src/clj/milia/api/user.clj
@@ -90,7 +90,9 @@
         url (make-url "profiles" username "change_password")
         data {:form-params {:current_password current-password
                             :new_password new-password}
-              :raw-response? true}]
+              :raw-response? true
+              :suppress-40x-exceptions? true
+              :as-map? true}]
     (parse-http :post url account data)))
 
 (defn retrieve-metadata

--- a/src/cljx/milia/api/http.cljx
+++ b/src/cljx/milia/api/http.cljx
@@ -34,7 +34,7 @@
                                            raw-response?)]
        (when (env :debug-api?)
          (debug-api method url appended-options response))
-       (when (and (in? [400 401 404] status) (not suppress-40x-exceptions?))?
+       (when (and (in? [400 401 404] status) (not suppress-40x-exceptions?))
          (throw+ {:api-response-status status :parsed-api-response parsed-response}))
        (if as-map?
          (assoc response :body parsed-response)

--- a/src/cljx/milia/api/http.cljx
+++ b/src/cljx/milia/api/http.cljx
@@ -34,7 +34,7 @@
                                            raw-response?)]
        (when (env :debug-api?)
          (debug-api method url appended-options response))
-       (when (and (in? [400 401 404] status) (not suppress-40x-exceptions?))
+       (when (and (in? [400 401 404] status) (not suppress-40x-exceptions?))?
          (throw+ {:api-response-status status :parsed-api-response parsed-response}))
        (if as-map?
          (assoc response :body parsed-response)

--- a/tests/clj/milia/api/user_test.clj
+++ b/tests/clj/milia/api/user_test.clj
@@ -88,7 +88,9 @@
                             account
                             {:form-params {:current_password :current_password
                                            :new_password :new_password}
-                             :raw-response? true}) => :updated)))
+                             :raw-response? true
+                             :suppress-40x-exceptions? true
+                             :as-map? true}) => :updated)))
 
   (facts "About metadata"
          (fact "Should return metadata"


### PR DESCRIPTION
Fixed the error thrown when one changes a password in ona.
This error is thrown when a user enters a wrong current password is entered.
closes https://github.com/onaio/zebra/issues/2242