### PR TITLE
Timestamp all xhr requests

### DIFF
--- a/src/milia/api/http.cljc
+++ b/src/milia/api/http.cljc
@@ -51,8 +51,11 @@
               headers (token->headers :token auth-token
                                       :get-crsftoken? (= method http/delete)
                                       :must-revalidate? must-revalidate?)
-              time-params (when no-cache?
+              ;; Add timestamp query param to all XHR requests
+              ;; (to be remove in next release)
+              time-params (when true
                             {:t (md5 (.toString (.now js/Date)))})
+              options (merge options {:query-params time-params})
               all-params (merge options
                                 {:xhr true
                                  :headers headers

--- a/src/milia/api/http.cljc
+++ b/src/milia/api/http.cljc
@@ -52,9 +52,9 @@
                                       :get-crsftoken? (= method http/delete)
                                       :must-revalidate? must-revalidate?)
               ;; Add timestamp query param to all XHR requests
-              ;; (to be remove in next release)
+              ;; (to be removed in next release)
               time-params (when true
-                            {:t (md5 (.toString (.now js/Date)))})
+                            {:t (md5 "20150716")})
               options (merge options {:query-params time-params})
               all-params (merge options
                                 {:xhr true

--- a/src/milia/api/io.cljs
+++ b/src/milia/api/io.cljs
@@ -86,7 +86,10 @@
                          :form-params :query-params)
              headers (token->headers :token (apply str token)
                                      :get-crsftoken? (= http-method http/delete))
-             time-params (when no-cache? {:t (md5 (.toString (.now js/Date)))})
+
+             ;; Add timestamp query param to all XHR requests
+             ;; (to be remove in next release)
+             time-params (when true {:t (md5 (.toString (.now js/Date)))})
              query-params (merge query-params time-params {:xhr true})]
          (http-method url {:headers headers param-key query-params})))))
 

--- a/src/milia/api/io.cljs
+++ b/src/milia/api/io.cljs
@@ -88,8 +88,8 @@
                                      :get-crsftoken? (= http-method http/delete))
 
              ;; Add timestamp query param to all XHR requests
-             ;; (to be remove in next release)
-             time-params (when true {:t (md5 (.toString (.now js/Date)))})
+             ;; (to be removed in next release)
+             time-params (when true {:t (md5 "20150716")})
              query-params (merge query-params time-params {:xhr true})]
          (http-method url {:headers headers param-key query-params})))))
 


### PR DESCRIPTION
Adds a timestamp to all XHR requests to disable cache on first load for all users. This is to avoid having all users clear cache. Should be removed on next release.