### PR TITLE
assume a nil status indicates an exception and avoid error of comparing to nil

### DIFF
--- a/src/milia/api/http.cljc
+++ b/src/milia/api/http.cljc
@@ -28,8 +28,10 @@
                                            filename
                                            raw-response?)]
        (debug-api method url http-options response)
-       (when (and (>= status 400) (< status 500)
-                  (not suppress-4xx-exceptions?))
+       ;; Assume that a nil status indicates an exception
+       (when (or (nil? status)
+                 (and (>= status 400) (< status 500)
+                      (not suppress-4xx-exceptions?)))
          (throw+ {:api-response-status status
                   :parsed-api-response parsed-response}))
        (if as-map?

--- a/src/milia/api/io.clj
+++ b/src/milia/api/io.clj
@@ -137,7 +137,6 @@
 (defn http-request
   "Send an HTTP request and catch some exceptions."
   [method url http-options]
-  ;; If nil, set req to {} as clj-http expects
   (let [req-fn #(call-client-method method url (build-req http-options))]
     (try+  ; Catch all bad statuses
      (try+ ; Catch 401 with token expire messages


### PR DESCRIPTION
Addresses things like:

```

Host
beta.ona.io
Message
Traceback (most recent last):

clojure.lang.Numbers.ops(Numbers.java:1013)
clojure.lang.Numbers.gte(Numbers.java:233)
clojure.lang.Numbers.gte(Numbers.java:3888)
milia.api.http$parse_http.doInvoke(http.cljc:31)
clojure.lang.RestFn.invoke(RestFn.java:464)
milia.api.dataset$patch.invoke(dataset.cljc:46)
ona.viewer.views.datasets$create.invoke(datasets.clj:216)
ona.viewer.routes$fn__25519$fn__25525.invoke(routes.clj:135)
compojure.core$make_route$fn__15106.invoke(core.clj:113)
compojure.core$wrap_route_middleware$fn__15102.invoke(core.clj:103)
compojure.core$if_route$fn__15085.invoke(core.clj:41)
compojure.core$if_method$fn__15077.invoke(core.clj:27)
compojure.core$routing$fn__15112.invoke(core.clj:127)
clojure.core$some.invoke(core.clj:2570)
compojure.core$routing.doInvoke(core.clj:127)
clojure.lang.RestFn.invoke(RestFn.java:460)
ona.viewer.routes$fn__25519.invoke(routes.clj:127)
compojure.core$if_context$fn__15134.invoke(core.clj:194)
compojure.core$routing$fn__15112.invoke(core.clj:127)
clojure.core$some.invoke(core.clj:2570)
compojure.core$routing.doInvoke(core.clj:127)
clojure.lang.RestFn.applyTo(RestFn.java:139)
clojure.core$apply.invoke(core.clj:632)
compojure.core$routes$fn__15116.invoke(core.clj:132)
compojure.core$routing$fn__15112.invoke(core.clj:127)
clojure.core$some.invoke(core.clj:2570)
compojure.core$routing.doInvoke(core.clj:127)
clojure.lang.RestFn.applyTo(RestFn.java:139)
clojure.core$apply.invoke(core.clj:632)
compojure.core$routes$fn__15116.invoke(core.clj:132)
compojure.core$routing$fn__15112.invoke(core.clj:127)
clojure.core$some.invoke(core.clj:2570)
compojure.core$routing.doInvoke(core.clj:127)
clojure.lang.RestFn.applyTo(RestFn.java:139)
clojure.core$apply.invoke(core.clj:632)
compojure.core$routes$fn__15116.invoke(core.clj:132)
ona.viewer.wrappers$wrap_error_handler$fn__24519.invoke(wrappers.clj:40)
ona.viewer.wrappers$wrap_account$fn__24509.invoke(wrappers.clj:33)
ring.middleware.flash$wrap_flash$fn__24571.invoke(flash.clj:35)
ring.middleware.session$wrap_session$fn__24723.invoke(session.clj:98)
ring.middleware.keyword_params$wrap_keyword_params$fn__24751.invoke(keyword_params.clj:35)
ring.middleware.nested_params$wrap_nested_params$fn__24795.invoke(nested_params.clj:84)
ring.middleware.multipart_params$wrap_multipart_params$fn__24901.invoke(multipart_params.clj:118)
ring.middleware.params$wrap_params$fn__24921.invoke(params.clj:64)
ring.middleware.cookies$wrap_cookies$fn__24682.invoke(cookies.clj:158)
ring.middleware.absolute_redirects$wrap_absolute_redirects$fn__25017.invoke(absolute_redirects.clj:36)
ring.middleware.resource$wrap_resource$fn__24939.invoke(resource.clj:26)
ring.middleware.content_type$wrap_content_type$fn__24986.invoke(content_type.clj:30)
ring.middleware.default_charset$wrap_default_charset$fn__25000.invoke(default_charset.clj:26)
ring.middleware.not_modified$wrap_not_modified$fn__24973.invoke(not_modified.clj:44)
ring.middleware.x_headers$wrap_xss_protection$fn__24555.invoke(x_headers.clj:71)
ring.middleware.x_headers$wrap_frame_options$fn__24543.invoke(x_headers.clj:38)
ring.middleware.x_headers$wrap_content_type_options$fn__24549.invoke(x_headers.clj:53)
ring.middleware.logger$make_logger_middleware$fn__25373.invoke(logger.clj:148)
ring.middleware.gzip$wrap_gzip$fn__25089.invoke(gzip.clj:69)
ring.adapter.jetty$proxy_handler$fn__25855.invoke(jetty.clj:20)
ring.adapter.jetty.proxy$org.eclipse.jetty.server.handler.AbstractHandler$ff19274a.handle(Unknown Source)
org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:116)
org.eclipse.jetty.server.Server.handle(Server.java:369)
org.eclipse.jetty.server.AbstractHttpConnection.handleRequest(AbstractHttpConnection.java:486)
org.eclipse.jetty.server.AbstractHttpConnection.content(AbstractHttpConnection.java:944)
org.eclipse.jetty.server.AbstractHttpConnection$RequestHandler.content(AbstractHttpConnection.java:1005)
org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:865)
org.eclipse.jetty.http.HttpParser.parseAvailable(HttpParser.java:240)
org.eclipse.jetty.server.AsyncHttpConnection.handle(AsyncHttpConnection.java:82)
org.eclipse.jetty.io.nio.SelectChannelEndPoint.handle(SelectChannelEndPoint.java:668)
org.eclipse.jetty.io.nio.SelectChannelEndPoint$1.run(SelectChannelEndPoint.java:52)
org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:608)
org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:543)
java.lang.Thread.run(Thread.java:745)

Request Object:

{:ssl-client-cert nil,
 :cookies
 {"ring-session"
  {:value "session:b1b8424a-95bf-422f-a4f3-0f213375e98e"},
  "ona.io-session"
  {:value "session:2eb900eb-0428-47c6-9564-f871afd9381c"},
  "production-session"
  {:value "session:f4c2ae70-027d-4775-9c21-543744306411"},
  "_ga" {:value "GA1.2.84288346.1433312830"}},
 :remote-addr "127.0.0.1",
 :params
 {:file
  {:filename "concern_kenya_IDSUE_Final.xlsx",
   :content-type
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   :tempfile
   #object[java.io.File 0x11d8aaea "/tmp/ring-multipart-6096701275732751551.tmp"],
   :size 179103},
  :dataset-id "69656"},
 :flash nil,
 :headers
 {"origin" "https://beta.ona.io",
  "x-forwarded-host" "beta.ona.io",
  "host" "beta.ona.io",
  "user-agent"
  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.125 Safari/537.36",
  "content-type"
  "multipart/form-data; boundary=----WebKitFormBoundaryApBPVFN017dFg0Jf",
  "cookie"
  "ring-session=session%3Ab1b8424a-95bf-422f-a4f3-0f213375e98e; ona.io-session=session%3A2eb900eb-0428-47c6-9564-f871afd9381c; production-session=session%3Af4c2ae70-027d-4775-9c21-543744306411; _ga=GA1.2.84288346.1433312830",
  "content-length" "179464",
  "referer" "https://beta.ona.io/onasupport/2812",
  "connection" "close",
  "upgrade-insecure-requests" "1",
  "accept"
  "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
  "accept-language" "en-US,en;q=0.8,fr;q=0.6,es;q=0.4",
  "x-forwarded-for" "41.57.103.171",
  "accept-encoding" "gzip, deflate",
  "x-real-ip" "41.57.103.171",
  "cache-control" "max-age=0"},
 :account {:api_token :REDACTED},
 :server-port 80,
 :content-length 179464,
 :form-params {},
 :session/key "session:f4c2ae70-027d-4775-9c21-543744306411",
 :query-params {},
 :content-type
 "multipart/form-data; boundary=----WebKitFormBoundaryApBPVFN017dFg0Jf",
 :character-encoding nil,
 :uri "/onasupport/2812/new",
 :server-name "beta.ona.io",
 :query-string nil,
 :body
 #object[org.eclipse.jetty.server.HttpInput 0x57ad3b34 "org.eclipse.jetty.server.HttpInput@57ad3b34"],
 :multipart-params
 {"file"
  {:filename "concern_kenya_IDSUE_Final.xlsx",
   :content-type
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   :tempfile
   #object[java.io.File 0x11d8aaea "/tmp/ring-multipart-6096701275732751551.tmp"],
   :size 179103},
  "dataset-id" "69656"},
 :scheme :http,
 :request-method :post,
 :session
 {:account
  {:joined_on "2014-01-27T14:30:41.328Z",
   :email "smusula@ona.io",
   :first_name "Ona ",
   :temp-token "236b98839fa0a9dd3c3c183554598e3a52216332",
   :gravatar
   "https://secure.gravatar.com/avatar/e3816766a2103a051946406f3daf3e23?s=60&d=https%3A%2F%2Fona.io%2Fstatic%2Fimages%2Fdefault_avatar.png",
   :name "Ona   Support Team",
   :twitter "",
   :is_org false,
   :temp_token :REDACTED,
   :city "Nairobi & NYC",
   :username "onasupport",
   :organization "Ona ",
   :token "138a7ff6dfdcb5b4e41eb2d39bcc76ce5d296e89",
   :id 108,
   :url "https://ona.io/api/v1/profiles/onasupport",
   :website "company.ona.io",
   :last_name " Support Team",
   :require_auth false,
   :api_token :REDACTED,
   :user "https://ona.io/api/v1/users/onasupport",
   :country "US",
   :metadata
   {:language-code "en",
    :zebra
    {:hide-data-view-walkthrough? true,
     :hide-share-modal-walkthrough? true,
     :hide-project-view-walkthrough? true,
     :hide-home-walkthrough? true}}}}}
```