### PR TITLE
Add support for synchronous downloads by submission ID

### DIFF
--- a/src/milia/api/dataset.cljc
+++ b/src/milia/api/dataset.cljc
@@ -135,6 +135,25 @@
             filename (filename-for-format dataset-id format)]
         (parse-http :get url :http-options options :filename filename)))))
 
+(defn download-synchronously
+  "Download form data in specified format. The synchronicity here refers to the
+   server side. This will still return a channel, not data, in CLJS.
+   The options map (last parameter) has the following keys:
+   :accept-header Defaults to application/json
+   :submission-id The id of the submission whose data the client requires. The
+    function returns data for all submissions if this is not provided.
+   :dataview? Boolean flag indicating whether the data belongs to a filtered
+    dataview"
+  [dataset-id format
+   & {:keys [accept-header submission-id dataview?]}]
+  (let [url (cond
+             dataview? (make-url "dataviews" dataset-id (str "data." format))
+             submission-id (make-url "data" dataset-id (str submission-id "." format))
+             :default (make-url "data" (str dataset-id "." format)))]
+    (parse-http :get url
+                :accept-header accept-header
+                :http-options (options-for-format format))))
+
 (defn form
   "Download form as JSON string or file in specified format if format passed."
   ([dataset-id]

--- a/tests/clj/milia/api/dataset_test.clj
+++ b/tests/clj/milia/api/dataset_test.clj
@@ -149,6 +149,44 @@
                   (parse-http :get url :http-options {:as :byte-array}
                               :filename filename) => :fake-file))))
 
+  (facts "about download-synchronously"
+    (let [format "leet"
+          accept-header "text/leet"
+          dataset-id 1337
+          submission-id 42
+          form-data-url (make-url "data" (str dataset-id "." format))
+          form-data-url-with-submission-id
+          (make-url "data" dataset-id (str submission-id
+                                           "."
+                                           format))
+          dataview-data-url (make-url "dataviews" dataset-id (str "data." format))]
+      (fact "calls parse-http with the correct parameters for forms"
+        (download-synchronously dataset-id format
+                                :accept-header accept-header)
+        => :response
+        (provided
+         (parse-http :get form-data-url
+                     :accept-header accept-header
+                     :http-options {}) => :response))
+      (fact "calls parse-http with the correct parameters for forms given a submission-id"
+        (download-synchronously dataset-id format
+                                :accept-header accept-header
+                                :submission-id submission-id)
+        => :response
+        (provided
+         (parse-http :get form-data-url-with-submission-id
+                     :accept-header accept-header
+                     :http-options {}) => :response))
+      (fact "calls parse-http with the correct parameters for filtered dataview"
+        (download-synchronously dataset-id format
+                                :accept-header accept-header
+                                :dataview? true)
+        => :response
+        (provided
+         (parse-http :get dataview-data-url
+                     :accept-header accept-header
+                     :http-options {}) => :response))))
+
   (facts "about dataset form"
          (fact "Return JSON string"
                (form :dataset-id) => :json


### PR DESCRIPTION
Closes #104

A follow up to this would be to find a way to combine the functionality of this function, the CLJ-only download function (which supports async downloads, but has no support for setting accept headers, or being used from CLJS), and the data function which has no support for filtering data by submission ID, and no support for filtered dataviews. An alternative would be to retain them but narrow down their functionality. e.g. by making `download` only support async downloads, in keeping with the Single Responsibility principle.