### PR TITLE
PLD: merge download and download-sync into a single cljc function

### DIFF
--- a/src/milia/api/dataset.cljc
+++ b/src/milia/api/dataset.cljc
@@ -128,9 +128,10 @@
    :dataview? Boolean flag indicating whether the data belongs to a filtered
     dataview.
    :async Download the data asynchronously, default is false. The synchronicity
-    here refers to the server side. This will still return a channel, not
-    data, in CLJS. This only applies if dataview? and submission-id are
-    falsey."
+    here refers to the server side. This will still return a channel, not data,
+    in CLJS. This only applies if dataview? and submission-id are falsey.
+   :filename Unless nil, store the response in this filename. In CLJS the
+    default is nil, in CLJ the default is dataset-ID dot format."
   [dataset-id format
    & {:keys [accept-header async submission-id dataview?]}]
   (let [url (cond

--- a/tests/clj/milia/api/dataset_test.clj
+++ b/tests/clj/milia/api/dataset_test.clj
@@ -149,7 +149,7 @@
                   (parse-http :get url :http-options {:as :byte-array}
                               :filename filename) => :fake-file))))
 
-  (facts "about download-synchronously"
+  (facts "about download options"
     (let [format "leet"
           accept-header "text/leet"
           dataset-id 1337
@@ -159,33 +159,36 @@
           (make-url "data" dataset-id (str submission-id
                                            "."
                                            format))
-          dataview-data-url (make-url "dataviews" dataset-id (str "data." format))]
+          dataview-data-url (make-url "dataviews" dataset-id
+                                      (str "data." format))]
       (fact "calls parse-http with the correct parameters for forms"
-        (download-synchronously dataset-id format
-                                :accept-header accept-header)
-        => :response
-        (provided
-         (parse-http :get form-data-url
-                     :accept-header accept-header
-                     :http-options {}) => :response))
-      (fact "calls parse-http with the correct parameters for forms given a submission-id"
-        (download-synchronously dataset-id format
-                                :accept-header accept-header
-                                :submission-id submission-id)
-        => :response
-        (provided
-         (parse-http :get form-data-url-with-submission-id
-                     :accept-header accept-header
-                     :http-options {}) => :response))
-      (fact "calls parse-http with the correct parameters for filtered dataview"
-        (download-synchronously dataset-id format
-                                :accept-header accept-header
-                                :dataview? true)
-        => :response
-        (provided
-         (parse-http :get dataview-data-url
-                     :accept-header accept-header
-                     :http-options {}) => :response))))
+            (download dataset-id format
+                      :accept-header accept-header)
+            => :response
+            (provided
+             (parse-http :get form-data-url
+                         :accept-header accept-header
+                         :http-options {}) => :response))
+      (fact "calls parse-http with the correct parameters for forms given a
+             submission-id"
+            (download dataset-id format
+                      :accept-header accept-header
+                      :submission-id submission-id)
+            => :response
+            (provided
+             (parse-http :get form-data-url-with-submission-id
+                         :accept-header accept-header
+                         :http-options {}) => :response))
+      (fact "calls parse-http with the correct parameters for filtered
+             dataview"
+            (download dataset-id format
+                      :accept-header accept-header
+                      :dataview? true)
+            => :response
+            (provided
+             (parse-http :get dataview-data-url
+                         :accept-header accept-header
+                         :http-options {}) => :response))))
 
   (facts "about dataset form"
          (fact "Return JSON string"

--- a/tests/clj/milia/api/dataset_test.clj
+++ b/tests/clj/milia/api/dataset_test.clj
@@ -116,17 +116,17 @@
                  (download :dataset-id format) => :fake-file
                  (provided
                   (make-url "data" filename) => url
-                  (parse-http :get url :http-options {}
-                              :filename filename) => :fake-file)))
+                  (parse-http :get url :accept-header nil :filename filename
+                              :http-options {}) => :fake-file)))
 
          (fact "Should change URL for async"
                (let [format "csv"
                      filename (str :dataset-id "." format)]
-                 (download :dataset-id format true) => :fake-file
+                 (download :dataset-id format :async true) => :fake-file
                  (provided
                   (make-url "forms" filename) => url
-                  (parse-http :get url :http-options {}
-                              :filename filename) => :fake-file)))
+                  (parse-http :get url :accept-header nil :filename filename
+                              :http-options {}) => :fake-file)))
 
          (fact "Should handle XLS as byte array"
                (let [format "xls"
@@ -134,10 +134,9 @@
                  (download :dataset-id format) => :fake-file
                  (provided
                   (make-url "data" filename) => url
-                  (parse-http :get
-                              url
-                              :http-options {:as :byte-array}
-                              :filename filename) => :fake-file)))
+                  (parse-http :get url :accept-header nil
+                              :filename filename
+                              :http-options {:as :byte-array}) => :fake-file)))
 
          (fact "Should handle csvzip zip extension"
                (let [format "csvzip"
@@ -146,15 +145,17 @@
                  (download :dataset-id format) => :fake-file
                  (provided
                   (make-url "data" path) => url
-                  (parse-http :get url :http-options {:as :byte-array}
-                              :filename filename) => :fake-file))))
+                  (parse-http :get url :accept-header nil :filename filename
+                              :http-options
+                              {:as :byte-array}) => :fake-file))))
 
-  (facts "about download options"
+  (facts "about download syncronously options"
     (let [format "leet"
           accept-header "text/leet"
           dataset-id 1337
+          filename (str dataset-id "." format)
           submission-id 42
-          form-data-url (make-url "data" (str dataset-id "." format))
+          form-data-url (make-url "data" filename)
           form-data-url-with-submission-id
           (make-url "data" dataset-id (str submission-id
                                            "."
@@ -168,6 +169,7 @@
             (provided
              (parse-http :get form-data-url
                          :accept-header accept-header
+                         :filename filename
                          :http-options {}) => :response))
       (fact "calls parse-http with the correct parameters for forms given a
              submission-id"
@@ -178,6 +180,7 @@
             (provided
              (parse-http :get form-data-url-with-submission-id
                          :accept-header accept-header
+                         :filename filename
                          :http-options {}) => :response))
       (fact "calls parse-http with the correct parameters for filtered
              dataview"
@@ -188,6 +191,7 @@
             (provided
              (parse-http :get dataview-data-url
                          :accept-header accept-header
+                         :filename filename
                          :http-options {}) => :response))))
 
   (facts "about dataset form"


### PR DESCRIPTION
@okal this is a pass at merging into a single function.

The reason it was CLJ only to start was because this _downloads_ something as a file, which CLJS cannot do.

This is now represented by telling it to pass a filename if it's CLJ and not if it's CLJS.

But, I could imagine a case where you'd not a file from CLJ, so the user should be able to override this.

Todo:
- [x] make filename an option, default to on for CLJ to match existing functionality
