### PR TITLE
PLD: generic retry function, use in async exports

### DIFF
--- a/src/milia/utils/file.clj
+++ b/src/milia/utils/file.clj
@@ -2,12 +2,14 @@
   (:require [clojure.java.io :as io])
   (:import [org.apache.commons.io IOUtils]))
 
-(defn to-byte-array [data-file]
+(defn to-byte-array
+  [data-file]
   (IOUtils/toByteArray (io/input-stream data-file)))
 
-(defn uploaded->file [uploaded-file]
-  (let [{:keys [tempfile filename]} uploaded-file
-        tempdir (com.google.common.io.Files/createTempDir)
+(defn uploaded->file
+  "Copy a tempfile into an actual file in a tempdir."
+  [{:keys [tempfile filename]}]
+  (let [tempdir (com.google.common.io.Files/createTempDir)
         path (str (.getAbsolutePath tempdir) "/" filename)
         file (clojure.java.io/file path)]
     (.deleteOnExit file)

--- a/src/milia/utils/retry.cljc
+++ b/src/milia/utils/retry.cljc
@@ -1,0 +1,24 @@
+(ns milia.utils.retry
+  #?(:cljs (:require-macros [cljs.core.async.macros :refer [go]]))
+  (:require [chimera.seq :refer [in? mapply]]
+            [milia.api.http :refer [parse-http]]))
+
+(def default-max-retries 1)
+(def default-retry-for-statuses [502 503 504])
+(def retry-keys [:max-retries :retry-for-statuses])
+
+(defn retry-parse-http
+  [method url & {:as options
+                 :keys [max-retries retry-for-statuses]
+                 :or {max-retries default-max-retries
+                      retry-for-statuses default-retry-for-statuses}}]
+  (#?(:cljs go :clj identity)
+   (loop [retry-count 0]
+     (let [{:keys [status] :as response}
+           (#?(:cljs <! :clj identity)
+            (mapply parse-http method url (apply dissoc options retry-keys)))]
+       (if (and (in? retry-for-statuses status) (< retry-count max-retries))
+         ;; retry
+         (recur (inc retry-count))
+         ;; exit
+         response)))))


### PR DESCRIPTION
Add retry logic to the async-export functionality, it's a generic `retry-parse-http` that we can add elsewhere or even move directly into `parse-http` if we think that's worthwhile.

By default this retries the request once if the status code returned is one of 502, 503, or 504. You can pass args to vary the number of retries the statuses on which to retry.

closes https://github.com/onaio/zebra/issues/4134