### PR TITLE
Export some functions and add helpers for JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,29 @@ Set the environment variable `DEBUG_API` to true to enable console debugging out
 
 ## Using Milia in JavaScript
 
-To use milia in JavaScript you will have to
+To use milia in JavaScript you will have to compile milia and then refer to the compiled output in your JavaScript code.
+Below are example steps to follow and an example HTML file using the basic features of milia.
 
-1. Compile the ClojureScript code to JavaScript: `lein cljsbuild once prod`.
-2. Load the compiled JavaScript into your application.
+1. Compile the ClojureScript code to JavaScript: `lein cljsbuild once prod`
+2. Copy the output JavaScript from `resources/public/js/lib/milia.js`, local to your root milia folder to the location of your choice.
+3. Load the compiled JavaScript into your application.
 3. Use the JavaScript helpers in `milia.utils.remote` to the set the remote server and the credentials to authenticate against that server.
 4. Only call milia functions that are `export`ed to JavaScript.
+
+For example:
+
+```html
+<html>
+  <script type="text/javascript" src="resources/public/js/lib/milia.js"></script>
+  <script type="text/javascript">
+    milia.utils.remote.set_hosts("api.ona.io");
+    milia.utils.remote.set_credentials("[username]", "[password]");
+    milia.api.dataset.data(21438);
+  </script>
+</html>
+```
+
+> NOTE: In the above, and any other HTML example, the domain hosting the HTML page must have cross-origin access rights to the Ona server you are requesting data from.
 
 ## [TODO] Proposed Client Architecture
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,17 @@ You can change the remote server URLs by importing and updating the hosts atom:
 
 Set the environment variable `DEBUG_API` to true to enable console debugging output on API requests.
 
+## Using Milia in JavaScript
+
+To use milia in JavaScript you will have to
+
+1. Compile the ClojureScript code to JavaScript: `lein cljsbuild once prod`.
+2. Load the compiled JavaScript into your application.
+3. Use the JavaScript helpers in `milia.utils.remote` to the set the remote server and the credentials to authenticate against that server.
+4. Only call milia functions that are `export`ed to JavaScript.
+
 ## [TODO] Proposed Client Architecture
+
 Convert remaining API endpoint files to cljc:
 
 * charts

--- a/src/milia/api/dataset.cljc
+++ b/src/milia/api/dataset.cljc
@@ -82,7 +82,7 @@
   (let [url (make-url "forms" dataset-id)]
     (parse-http :put url :http-options {:form-params params})))
 
-(defn data
+(defn ^:export data
   "Return the data associated with a dataset."
   [dataset-id &
    {:keys [format raw? must-revalidate? accept-header query-params

--- a/src/milia/api/user.cljc
+++ b/src/milia/api/user.cljc
@@ -31,12 +31,10 @@
 
 (defn user
   "Return the user profile with authentication details."
-  ([]
-   (user false))
-  ([suppress-4xx-exceptions?]
-   (let [url (make-url "user")]
-     (parse-http :get url
-                 :suppress-4xx-exceptions? suppress-4xx-exceptions?))))
+  [& [suppress-4xx-exceptions?]]
+  (let [url (make-url "user")]
+    (parse-http :get url
+                :suppress-4xx-exceptions? suppress-4xx-exceptions?)))
 
 (defn create
   "Create a new user."

--- a/src/milia/utils/remote.cljc
+++ b/src/milia/utils/remote.cljc
@@ -28,6 +28,35 @@
          ;; protocol to use in all requests
          :request-protocol "https"}))
 
+(defn ^:export set-hosts
+  "Swap values into hosts atom, requires data-host, other args are option but
+   must be provided in order. If an option arg is nil it is ignored, and not
+   swapped into hosts.
+
+   Built to support setting hosts from JavaScript."
+  [data-host & [client-host j2x-host request-protocol]]
+  (swap! hosts merge
+         (cond-> {:data data-host}
+           (some? client-host) (assoc :client client-host)
+           (some? j2x-host) (assoc :j2x j2x-host)
+           (some? request-protocol)
+           (assoc :request-protocol request-protocol))))
+
+(defn ^:export set-credentials
+  "Set the dynamic credentials to include the username and optionally
+   any other arguments that are passed. If an argument is nil or not passed
+   it will be set to nil in the credentials.
+
+   Calling this from Clojure will break if not done from within a previous
+   binding of the *credentials* variable.
+
+   Built to support setting hosts from JavaScript."
+  [username & [password temp-token token]]
+  (set! *credentials* {:username username
+                       :password password
+                       :temp-token temp-token
+                       :token token}))
+
 (defn protocol-prefixed
   "Prefix the resources with the protocol and format strings."
   [resources] (-> [(:request-protocol @hosts) "://" resources]

--- a/tests/clj/milia/utils/remote_test.clj
+++ b/tests/clj/milia/utils/remote_test.clj
@@ -1,0 +1,46 @@
+(ns milia.utils.remote-test
+  (:require [midje.sweet :refer :all]
+            [milia.utils.remote :refer :all]))
+
+(facts "about set-hosts"
+       (fact "should always swap in data-host"
+             (set-hosts :data-host) => (assoc  @hosts
+                                               :data :data-host))
+
+       (fact "should ignore passed nils"
+             (set-hosts :data-host nil nil nil)
+             => (merge {:data :data-host} @hosts))
+
+       (fact "should only ignore passed nils"
+             (set-hosts :data-host nil :j2x-host nil)
+             => (assoc @hosts :data :data-host :j2x :j2x-host))
+
+       (fact "should set all args"
+             (set-hosts :data-host :client-host :j2x-host :req-proto)
+             => (assoc @hosts
+                       :data :data-host
+                       :client :client-host
+                       :j2x :j2x-host
+                       :request-protocol :req-proto)))
+
+(binding [*credentials* {}]
+  (facts "about set-credentials"
+         (fact "should set username and others to nil"
+               (set-credentials :username) => {:username :username
+                                               :password nil
+                                               :temp-token nil
+                                               :token nil})
+
+         (fact "should set passed args"
+               (set-credentials :username nil :temp-token)
+               => {:username :username
+                   :password nil
+                   :temp-token :temp-token
+                   :token nil})
+
+         (fact "should set all passed args"
+               (set-credentials :username :password :temp-token :token)
+               => {:username :username
+                   :password :password
+                   :temp-token :temp-token
+                   :token :token})))


### PR DESCRIPTION
* add export on functions we JavaScript users of the library to have access to
  * (if it's not included it's more likely because we didn't bother than because it's intentionally restricted)
* add state helpers so JavaScript users can easily set the hosts and credentials