### PR TITLE
Vary the request method for update-xform-meta-permissions

### DIFF
--- a/src/milia/api/dataset.cljc
+++ b/src/milia/api/dataset.cljc
@@ -320,9 +320,9 @@
 
 (defn update-xform-meta-permissions
   "Integer String String -> Channel HttpRequest"
-  [dataset-id editor-meta-role dataentry-meta-role]
+  [dataset-id metadata-id method editor-meta-role dataentry-meta-role]
   (parse-http
-   :post (make-url "metadata")
+   method (make-url "metadata" metadata-id)
    :http-options
    {:form-params
     {:data_type  "xform_meta_perms"

--- a/src/milia/api/dataset.cljc
+++ b/src/milia/api/dataset.cljc
@@ -319,10 +319,21 @@
                     :extra-params extra-params)))
 
 (defn update-xform-meta-permissions
-  "Integer String String -> Channel HttpRequest"
-  [dataset-id metadata-id method editor-meta-role dataentry-meta-role]
+  "Integer Integer String String -> Channel HttpResponse"
+  [dataset-id metadata-id editor-meta-role dataentry-meta-role]
   (parse-http
-   method (make-url "metadata" metadata-id)
+   :put (make-url "metadata" metadata-id)
+   :http-options
+   {:form-params
+    {:data_type  "xform_meta_perms"
+     :xform      dataset-id
+     :data_value (str editor-meta-role "|" dataentry-meta-role)}}))
+
+(defn create-xform-meta-permissions
+  "Integer String String -> Channel HttpResponse"
+  [dataset-id editor-meta-role dataentry-meta-role]
+  (parse-http
+   :post (make-url "metadata")
    :http-options
    {:form-params
     {:data_type  "xform_meta_perms"

--- a/tests/clj/milia/api/dataset_test.clj
+++ b/tests/clj/milia/api/dataset_test.clj
@@ -526,18 +526,18 @@
                                                :content :file}]}
                    :suppress-4xx-exceptions? true)
        => :response))
-(fact "about update xform meta permissions POST"
-      (update-xform-meta-permissions 1 nil :post "editor-minor" "dataentry-only")
+(fact "about create xform meta permissions"
+      (create-xform-meta-permissions 1 "editor-minor" "dataentry-only")
       => :response
       (provided (parse-http
-                 :post (make-url "metadata" nil)
+                 :post (make-url "metadata")
                  :http-options
                  {:form-params {:data_type  "xform_meta_perms"
                                 :xform      1
                                 :data_value "editor-minor|dataentry-only"}})
                 => :response))
-(fact "about update xform meta permissions PUT"
-      (update-xform-meta-permissions 1 10 :put "editor-minor" "dataentry-only")
+(fact "about update xform meta permissions"
+      (update-xform-meta-permissions 1 10 "editor-minor" "dataentry-only")
       => :response
       (provided (parse-http
                  :put (make-url "metadata" 10)

--- a/tests/clj/milia/api/dataset_test.clj
+++ b/tests/clj/milia/api/dataset_test.clj
@@ -526,11 +526,21 @@
                                                :content :file}]}
                    :suppress-4xx-exceptions? true)
        => :response))
-(fact "about update xform meta permissions"
-      (update-xform-meta-permissions 1 "editor-minor" "dataentry-only")
+(fact "about update xform meta permissions POST"
+      (update-xform-meta-permissions 1 nil :post "editor-minor" "dataentry-only")
       => :response
       (provided (parse-http
-                 :post (make-url "metadata")
+                 :post (make-url "metadata" nil)
+                 :http-options
+                 {:form-params {:data_type  "xform_meta_perms"
+                                :xform      1
+                                :data_value "editor-minor|dataentry-only"}})
+                => :response))
+(fact "about update xform meta permissions PUT"
+      (update-xform-meta-permissions 1 10 :put "editor-minor" "dataentry-only")
+      => :response
+      (provided (parse-http
+                 :put (make-url "metadata" 10)
                  :http-options
                  {:form-params {:data_type  "xform_meta_perms"
                                 :xform      1


### PR DESCRIPTION
Make either a PUT or a POST depending on whether xform meta-permissions are already set.