### PR TITLE
Force reload in case of 401 response

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
    :milia-http-default-per-route "10"
    :milia-http-threads "20"})
 
-(defproject onaio/milia "0.3.27"
+(defproject onaio/milia "0.3.27-SNAPSHOT"
   :description "The ona.io Clojure Web API Client."
   :dependencies [;; CORE MILIA REQUIREMENTS
                  [cheshire "5.6.3"]

--- a/src/milia/api/io.cljs
+++ b/src/milia/api/io.cljs
@@ -124,6 +124,6 @@
       (let [original-response-channel (apply request-fn args)
             {:keys [status] :as response} (<! original-response-channel)]
         (if (= status 401)
-          (set! js/window.location js/window.location)
+          (set! js/window.location (.href js/window.location))
           (put! response-channel response))))
     response-channel))


### PR DESCRIPTION
401 responses should trigger a reload so that we get a new temp token.
Better yet, we can make an XHR request for a new token.

This works well in the clojure code `io.clj` but not clojurescript `io.cljs`.

closes #207 
