### PR TITLE
Add missing param

### DIFF
--- a/src/milia/api/dataset.cljc
+++ b/src/milia/api/dataset.cljc
@@ -13,7 +13,7 @@
 (defmulti type->endpoint (fn [datatype & _] datatype))
 (defmethod type->endpoint :default [_ & {:keys [async] :or {async true}}]
   (if async "forms" "data"))
-(defmethod type->endpoint :filtered-dataset [_ & [_]] "dataviews")
+(defmethod type->endpoint :filtered-dataset [_ & _] "dataviews")
 
 (defn all
   "Return all the datasets for an account."

--- a/src/milia/api/dataset.cljc
+++ b/src/milia/api/dataset.cljc
@@ -13,7 +13,7 @@
 (defmulti type->endpoint (fn [datatype & _] datatype))
 (defmethod type->endpoint :default [_ & {:keys [async] :or {async true}}]
   (if async "forms" "data"))
-(defmethod type->endpoint :filtered-dataset [_] "dataviews")
+(defmethod type->endpoint :filtered-dataset [_ & [_]] "dataviews")
 
 (defn all
   "Return all the datasets for an account."


### PR DESCRIPTION
Adding the unused param symbol because `type-endpoint` is called by [2 params by default](https://github.com/onaio/milia/blob/88f4b9e980c764601af4ec68adc6e69ed64f6fe3/src/milia/api/dataset.cljc#L155)