### PR TITLE
Make temp-token arg optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
-lein: lein2
 language: clojure
 script:
-    - lein2 bikeshed
-    - lein2 cljfmt check
-    - lein2 eastwood
-    - lein2 kibit
-    - lein2 midje
-    - lein2 cljsbuild once dev
-    - lein2 cljsbuild once prod
-    - lein2 cljsbuild test
+    - lein bikeshed
+    - lein cljfmt check
+    - lein eastwood
+    - lein kibit
+    - lein midje
+    - lein cljsbuild once dev
+    - lein cljsbuild once prod
+    - lein cljsbuild test
 notifications:
   email:
     - tech+travis@ona.io

--- a/src/milia/api/async_export.cljc
+++ b/src/milia/api/async_export.cljc
@@ -4,6 +4,7 @@
             #?@(:cljs [[goog.string.format]
                       [cljs.core.async :refer [<! chan put! timeout]]])
             [clojure.string :refer [join]]
+            [chimera.string :refer [is-not-null?]]
             [milia.api.dataset :refer [type->endpoint]]
             [milia.api.http :refer [parse-http]]
             [milia.utils.remote :refer [make-url *credentials*]]
@@ -185,11 +186,14 @@
 
 (defn get-exports-per-form
   "Get exports based on a form id."
-  [dataset-id temp-token]
+  [dataset-id & [temp-token]]
   (parse-http
    :get
    (make-url
-    (str "export?xform=" dataset-id "&temp_token=" temp-token))))
+    (str "export?xform="
+         dataset-id
+         (when (is-not-null? temp-token)
+          (str "&temp_token=" temp-token))))))
 
 (defn delete-export
   "Delete an export based on an export id"

--- a/src/milia/api/async_export.cljc
+++ b/src/milia/api/async_export.cljc
@@ -192,8 +192,7 @@
    (make-url
     (str "export?xform="
          dataset-id
-         (when (is-not-null? temp-token)
-          (str "&temp_token=" temp-token))))))
+         (some->> temp-token (str "&temp_token="))))))
 
 (defn delete-export
   "Delete an export based on an export id"


### PR DESCRIPTION
Make `temp-token` an optional param since it should not be included when a logged out user exports from a public project. i.e https://api.ona.io/api/v1/export/412631?format=csv&temp_token=null

Signed-off-by: Kipchirchir Sigei <arapgodsmack@gmail.com>