### PR TITLE
Make temp_token string optional 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
    :milia-http-default-per-route "10"
    :milia-http-threads "20"})
 
-(defproject onaio/milia "0.3.34"
+(defproject onaio/milia "0.3.35"
   :description "The ona.io Clojure Web API Client."
   :dependencies [;; CORE MILIA REQUIREMENTS
                  [cheshire "5.6.3"]

--- a/src/milia/api/async_export.cljc
+++ b/src/milia/api/async_export.cljc
@@ -21,9 +21,9 @@
    the first or a subsequenty query parameter."
   [& s]
   (let [temp-token (:temp-token *credentials*)]
-  (join (if (is-not-null? temp-token)
-          (conj (vec s) "temp_token=" temp-token)
-          s))))
+        (join (if (is-not-null? temp-token)
+                (conj (vec s) "temp_token=" temp-token)
+                s))))
 
 (defn- handle-response
   "Handles API server's response and acts according to given callbacks."

--- a/src/milia/api/async_export.cljc
+++ b/src/milia/api/async_export.cljc
@@ -1,6 +1,7 @@
 (ns milia.api.async-export
   #?(:cljs (:require-macros [cljs.core.async.macros :refer [go]]))
   (:require [chimera.seq :refer [select-values]]
+            [chimera.string :refer [is-not-null?]]
             #?@(:cljs [[goog.string.format]
                       [cljs.core.async :refer [<! chan put! timeout]]])
             [clojure.string :refer [join]]
@@ -19,9 +20,10 @@
    to explicity pass a question-mark or ampersand depending on whether this is
    the first or a subsequenty query parameter."
   [& s]
-  (join (if-let [temp-token (:temp-token *credentials*)]
-          (conj (vec s) "temp_token=" temp-token)
-          s)))
+  (let [temp-token (:temp-token *credentials*)]
+  (join (if (is-not-null? temp-token)
+          (conj (vec s) "&temp_token=" temp-token)
+          s))))
 
 (defn- handle-response
   "Handles API server's response and acts according to given callbacks."
@@ -196,7 +198,7 @@
   "Get exports based on a form id."
   [dataset-id]
   (parse-http :get
-              (make-url (temp-token-suffix "export?xform=" dataset-id "&"))))
+              (make-url (temp-token-suffix "export?xform=" dataset-id))))
 
 (defn delete-export
   "Delete an export based on an export id"

--- a/src/milia/api/async_export.cljc
+++ b/src/milia/api/async_export.cljc
@@ -22,7 +22,7 @@
   [& s]
   (let [temp-token (:temp-token *credentials*)]
   (join (if (is-not-null? temp-token)
-          (conj (vec s) "&temp_token=" temp-token)
+          (conj (vec s) "temp_token=" temp-token)
           s))))
 
 (defn- handle-response
@@ -198,7 +198,7 @@
   "Get exports based on a form id."
   [dataset-id]
   (parse-http :get
-              (make-url (temp-token-suffix "export?xform=" dataset-id))))
+              (make-url (temp-token-suffix "export?xform=" dataset-id "&"))))
 
 (defn delete-export
   "Delete an export based on an export id"


### PR DESCRIPTION
I have added a check for null in case a temp_token string is not available since it's usually null when absent. This was the reason why the logic of making it optional was not working previously.