### PR TITLE
Update endpoints expecting content-type: json header.

### DIFF
--- a/src/milia/api/organization.cljc
+++ b/src/milia/api/organization.cljc
@@ -108,16 +108,21 @@
                  :suppress-4xx-exceptions? true
                  :as-map? true))))
 
-#?(:cljs
-    (defn change-org-member-role
-      "Change the role of an organization member"
-      [member org-name event-chan]
-      (parse-http :put
-                  (make-url "orgs" org-name "members")
-                  :callback #(put! event-chan {:updated-member member})
-                  :http-options
-                  {:json-params {:username (:username member)
-                                 :role (:role member)}})))
+(defn change-org-member-role
+  "Change the role of an organization member"
+  [member org-name event-chan]
+  (let [data {:username (:username member)
+              :role (:role member)}]
+    (parse-http :put
+                (make-url "orgs" org-name "members")
+                :callback
+                #?(:clj nil)
+                #?(:cljs #(put! event-chan {:updated-member member}))
+                :http-options
+                #?(:clj   {:form-params data
+                           :content-type :json})
+                #?(:cljs {:json-params data})
+                :as-map? true)))
 
 (defn remove-member
   "Remove a user from an organization or organization team"

--- a/src/milia/api/organization.cljc
+++ b/src/milia/api/organization.cljc
@@ -110,23 +110,19 @@
 
 (defn change-org-member-role
   "Change the role of an organization member"
-  [member org-name event-chan add-callback?]
+  [member org-name event-chan]
   (let [data {:username (:username member)
               :role (:role member)}]
-    (apply parse-http (->
-                        [:put
-                         (make-url "orgs" org-name "members")
-                         :http-options
-                         #?(:clj   {:form-params data
-                                    :content-type :json})
-                         #?(:cljs {:json-params data})
-                          :as-map? true]
-                        (concat (when add-callback?
-                                  [:callback
-                                   #?(:cljs
-                                    #(put! event-chan
-                                           {:updated-member member}))]))
-                        (vec)))))
+    (parse-http :put
+                (make-url "orgs" org-name "members")
+                :callback
+                #?(:clj nil
+                   :cljs #(put! event-chan {:updated-member member}))
+                :http-options
+                #?(:clj   {:form-params data
+                           :content-type :json})
+                #?(:cljs {:json-params data})
+                :as-map? true)))
 
 (defn remove-member
   "Remove a user from an organization or organization team"

--- a/test/clj/milia/api/organization_test.clj
+++ b/test/clj/milia/api/organization_test.clj
@@ -128,12 +128,13 @@
 
 (facts "about change-org-member-role with assigned role"
        (fact "should change a member's role in an org"
-             (change-org-member-role fake-member :orgname nil false)
+             (change-org-member-role fake-member :orgname nil)
              => :something
              (provided
               (make-url "orgs" :orgname "members") => url
               (parse-http :put
                           url
+                          :callback nil
                           :http-options {:form-params
                                          {:username (:username fake-member)
                                           :role (:role fake-member)}

--- a/test/clj/milia/api/organization_test.clj
+++ b/test/clj/milia/api/organization_test.clj
@@ -128,13 +128,12 @@
 
 (facts "about change-org-member-role with assigned role"
        (fact "should change a member's role in an org"
-             (change-org-member-role fake-member :orgname nil)
+             (change-org-member-role fake-member :orgname nil false)
              => :something
              (provided
               (make-url "orgs" :orgname "members") => url
               (parse-http :put
                           url
-                          :callback nil
                           :http-options {:form-params
                                          {:username (:username fake-member)
                                           :role (:role fake-member)}

--- a/test/clj/milia/api/organization_test.clj
+++ b/test/clj/milia/api/organization_test.clj
@@ -126,6 +126,22 @@
                           :suppress-4xx-exceptions? true
                           :as-map? true) => :something)))
 
+(facts "about change-org-member-role with assigned role"
+       (fact "should change a member's role in an org"
+             (change-org-member-role fake-member :orgname nil)
+             => :something
+             (provided
+              (make-url "orgs" :orgname "members") => url
+              (parse-http :put
+                          url
+                          :callback nil
+                          :http-options {:form-params
+                                         {:username (:username fake-member)
+                                          :role (:role fake-member)}
+                                         :content-type :json}
+                          :as-map? true)
+              => :something)))
+
 (facts "about remove-member"
        (fact "should remove a member"
              (remove-member :orgname :member nil) => :something

--- a/test/clj/milia/api/organization_test.clj
+++ b/test/clj/milia/api/organization_test.clj
@@ -10,6 +10,7 @@
 (def password :fake-password)
 (def org-name :fake-org-name)
 (def fake-teams [{:organization org-name :name "name"}])
+(def fake-member {:username :username :role :role})
 (def org-profile {:org org-name})
 
 (facts "about organizations"
@@ -175,7 +176,9 @@
       (provided
        (make-url "teams" :team-id "share") => :url
        (parse-http :post :url
-                   :http-options {:form-params :data}) => :updated-team))
+                   :http-options {:form-params :data
+                                  :content-type :json}
+                   :as-map? true) => :updated-team))
 
 (facts "about can-user-create-project-under-organization?"
        (let [owner "i_own_this"


### PR DESCRIPTION
Adds a function for changing an org member role and adds `content-type: json` header to the `share-team` function `POST` request. 