### PR TITLE
Change default images url var

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
    :milia-http-default-per-route "10"
    :milia-http-threads "20"})
 
-(defproject onaio/milia "0.3.47"
+(defproject onaio/milia "0.3.48-SNAPSHOT"
   :description "The ona.io Clojure Web API Client."
   :dependencies [;; CORE MILIA REQUIREMENTS
                  [cheshire "5.6.3"]

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
    :milia-http-default-per-route "10"
    :milia-http-threads "20"})
 
-(defproject onaio/milia "0.3.48-SNAPSHOT"
+(defproject onaio/milia "0.3.48"
   :description "The ona.io Clojure Web API Client."
   :dependencies [;; CORE MILIA REQUIREMENTS
                  [cheshire "5.6.3"]

--- a/src/milia/utils/remote.cljc
+++ b/src/milia/utils/remote.cljc
@@ -27,6 +27,10 @@
           (read-env-string :milia-http-default-per-route)))
 #?(:clj (def http-threads (read-env-string :milia-http-threads)))
 
+(def images-url
+ #?(:clj "images.ona.io"
+    :cljs (str "images." (aget js/window "location" "hostname"))))
+
 (def hosts
   "Store remote hosts that requests are made to."
   (atom {
@@ -39,7 +43,7 @@
          ;; protocol to use in all requests
          :request-protocol "https"
          ;; thumbor url for images
-         :images "images.ona.io"}))
+         :images images-url}))
 
 (def timeouts
   "Store customizable timeouts to use in the http libraries. In milliseconds."


### PR DESCRIPTION
For CLJS, append the target server hostname to `images.`. For CLJ,
keep it as `images.ona.io`.

Signed-off-by: Mark Ekisa <mark.ekisa@gmail.com>