### PR TITLE
Increase Max Retries to Five

### DIFF
--- a/src/milia/api/user.cljc
+++ b/src/milia/api/user.cljc
@@ -24,7 +24,7 @@
   (let [url (make-url "profiles" (str username ".json"))
         response (retry-parse-http :get url
                                    :suppress-4xx-exceptions? true
-                                   :max-retries 2)]
+                                   :max-retries 5)]
     (if-let [error (:detail response)] nil response)))
 
 (defn verify-email


### PR DESCRIPTION
Related to this issue [#5911](https://github.com/onaio/zebra/issues/5911), increasing the max number of retries to 5 instead of 2. This gives us an allowance until the database is updated.
Signed-off-by: RayceeM <mwatelaraycee33@gmail.com>