### PR TITLE
Refactor dataset.clj to allow for uploading of .xml files

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
    :milia-http-default-per-route "10"
    :milia-http-threads "20"})
 
-(defproject onaio/milia "0.3.57"
+(defproject onaio/milia "0.3.58-rc"
   :description "The ona.io Clojure Web API Client."
   :dependencies [;; CORE MILIA REQUIREMENTS
                  [cheshire "5.6.3"]


### PR DESCRIPTION
Fixes: #293 

*Changes introduced in this PR*
- General refactor `milia.utils.remote` namespace
- Refactor `send-file-or-params` to allow for uploading of `.xml` files