### PR TITLE
Bump milia version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Install via clojars with:
 
 [![Clojars Project](http://clojars.org/onaio/milia/latest-version.svg)](http://clojars.org/onaio/milia)
 
+## Deploying to clojars
+
+lein deploy clojars
+
 ## Current API Endpoints
 * charts
 * forms

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
    :milia-http-default-per-route "10"
    :milia-http-threads "20"})
 
-(defproject onaio/milia "0.4.2-SNAPSHOT"
+(defproject onaio/milia "0.4.3"
   :description "The ona.io Clojure Web API Client."
   :dependencies [;; CORE MILIA REQUIREMENTS
                  [cheshire "5.6.3"]


### PR DESCRIPTION
- Add documentation for deploying to _clojars_
- Bump version from `0.4.2-SNAPSHOT` to `0.4.3`

## TODO

- [ ] create a release after merging this PR that includes the following
  - Default require-json to false #303
  - Encode download path #302
  - Remove : from default argument values using :or construct #301